### PR TITLE
Fix duplicate key

### DIFF
--- a/snippets/qtpro.cson
+++ b/snippets/qtpro.cson
@@ -5,7 +5,7 @@
   'LIBRARY':
     'prefix': 'LIBS'
     'body': 'LIBS += ${1:-lmath}'
-  'CXXFLAGS':
+  'QMAKE_CXXFLAGS':
     'prefix': 'QMAKE_CXXFLAGS'
     'body': 'QMAKE_CXXFLAGS += ${1:/J}'
   'CXXFLAGS':


### PR DESCRIPTION
Recent versions of Atom (at least 1.25.0-beta2) started reporting an error on startup about `language-qt-pro` having a duplicate key `CXX_FLAGS` in its snippets file. This change should fix the error, and shouldn't change behaviour in any way.