### PR TITLE
Syntax highlighting for project include file

### DIFF
--- a/grammars/qtpro.cson
+++ b/grammars/qtpro.cson
@@ -1,6 +1,6 @@
 'scopeName' : 'source.pro'
 'fileTypes' : [
-    'pro'
+    'pro', 'pri'
 ]
 'name' : 'Qt Project'
 'patterns' : [


### PR DESCRIPTION
Hi, the syntax highlighting works well for `*.pro` files. The same set of rules can be used for the `*.pri` [project include files](https://wiki.qt.io/Including_.pro_Files).